### PR TITLE
use addDeclaration function for varswithtypes

### DIFF
--- a/blockly/generators/arduino.js
+++ b/blockly/generators/arduino.js
@@ -119,11 +119,11 @@ Blockly.Arduino.init = function(workspace) {
   // Set variable declarations with their Arduino type in the defines dictionary
   var variableDeclarations = [];
   for (var varName in varsWithTypes) {
-    variableDeclarations.push(
-        Blockly.Arduino.getArduinoType_(varsWithTypes[varName]) + ' ' +
-        varName + ';');
+      if (Blockly.Arduino.definitions_[varName] === undefined) {
+        Blockly.Arduino.addDeclaration("auto_" + varName,  Blockly.Arduino.getArduinoType_(varsWithTypes[varName]) + " " + varName + ';');
+      }
   }
-  Blockly.Arduino.definitions_['variables'] = variableDeclarations.join('\n');
+  Blockly.Arduino.definitions_['variables'] = '';
 };
 
 /**


### PR DESCRIPTION
Use the existing addDeclaration function for the varsWithTypes declaration.
This has the advantage that the actual code does not generate yet at the start, so further changes can still be done. Also code reuse.
I add 'auto' here to indicate this was automatically determined. 

Use case: for my custom declare blocks, I need to remove automatic variable declaration, if a declare block is present. By using addDeclaration this becomes possible, see: https://github.com/bmcage/ardublockly/blob/blockly4arduino/blockly/generators/arduino/declare.js 
where the declare blocks can do:
`  //remove previous possible automatic declaration`
`  delete Blockly.Arduino.definitions_["auto_" + value_name];`
