### PR TITLE
Use the formatted name for global variable declartion.

### DIFF
--- a/blockly/generators/arduino.js
+++ b/blockly/generators/arduino.js
@@ -122,7 +122,7 @@ Blockly.Arduino.init = function(workspace) {
   for (var varName in varsWithTypes) {
     Blockly.Arduino.addVariable(varName,
         Blockly.Arduino.getArduinoType_(varsWithTypes[varName]) +' ' +
-        varName + ';');
+        Blockly.Arduino.variableDB_.getName(varName, Blockly.Variables.NAME_TYPE) + ';');
   }
 };
 


### PR DESCRIPTION
Fixes issue with spaces in variable names.