### PR TITLE
Fix: 'unicodeescape' error

### DIFF
--- a/ardublocklyserver/actions.py
+++ b/ardublocklyserver/actions.py
@@ -124,8 +124,8 @@ def load_arduino_cli(sketch_path):
                 cli_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 shell=False)
             std_out, err_out = process.communicate()
-            std_out = six.u(std_out)
-            err_out = six.u(err_out)
+            std_out = std_out.decode("utf-8")
+            err_out = err_out.decode("utf-8")
             exit_code = process.returncode
             print('Arduino output:\n%s' % std_out)
             print('Arduino Error output:\n%s' % err_out)


### PR DESCRIPTION
Changed the decoding from 'unicodeescape' to 'utf-8' to fix this error