### PR TITLE
Use HTTPS instead of HTTP in build.py

### DIFF
--- a/blockly/build.py
+++ b/blockly/build.py
@@ -270,7 +270,7 @@ class Gen_compressed(threading.Thread):
   def do_compile(self, params, target_filename, filenames, remove):
     # Send the request to Google.
     headers = {"Content-type": "application/x-www-form-urlencoded"}
-    conn = httplib.HTTPConnection("closure-compiler.appspot.com")
+    conn = httplib.HTTPSConnection("closure-compiler.appspot.com")
     conn.request("POST", "/compile", urllib.urlencode(params), headers)
     response = conn.getresponse()
     json_str = response.read()


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/blockly/EDxPuJQ37RI

Closure compiler no longer accepts HTTP requests, as of last Thursday.  It is now HTTPS only.