### PR TITLE
Fix RTL comparator operators

### DIFF
--- a/blockly/blocks/logic.js
+++ b/blockly/blocks/logic.js
@@ -275,10 +275,10 @@ Blockly.Blocks['logic_compare'] = {
     var OPERATORS = this.RTL ? [
           ['=', 'EQ'],
           ['\u2260', 'NEQ'],
-          ['>', 'LT'],
-          ['\u2265', 'LTE'],
-          ['<', 'GT'],
-          ['\u2264', 'GTE']
+          ['\u200F<\u200F', 'LT'],
+          ['\u200F\u2264\u200F', 'LTE'],
+          ['\u200F>\u200F', 'GT'],
+          ['\u200F\u2265\u200F', 'GTE']
         ] : [
           ['=', 'EQ'],
           ['\u2260', 'NEQ'],


### PR DESCRIPTION
In the current blockly version that is being used by ardublockly, when in RTL mode, comparator operators are not shown correctly! This can fix them!
The problem is shown in the picture below
![screenshot from 2018-05-23 10 26 24](https://user-images.githubusercontent.com/8184318/40408743-ce7fe7a4-5e7d-11e8-9280-7deb7dcd6508.png)
