### PR TITLE
Fixed closure compile error

### DIFF
--- a/blockly/build.py
+++ b/blockly/build.py
@@ -214,6 +214,7 @@ class Gen_compressed(threading.Thread):
     # Define the parameters for the POST request.
     params = [
         ("compilation_level", "SIMPLE_OPTIMIZATIONS"),
+        ("use_closure_library", "true"),
         ("output_format", "json"),
         ("output_info", "compiled_code"),
         ("output_info", "warnings"),
@@ -243,6 +244,7 @@ class Gen_compressed(threading.Thread):
     # Define the parameters for the POST request.
     params = [
         ("compilation_level", "SIMPLE_OPTIMIZATIONS"),
+        ("use_closure_library", "true"),
         ("output_format", "json"),
         ("output_info", "compiled_code"),
         ("output_info", "warnings"),

--- a/blockly/core/blockly.js
+++ b/blockly/core/blockly.js
@@ -53,6 +53,11 @@ goog.require('Blockly.inject');
 goog.require('Blockly.utils');
 goog.require('goog.color');
 goog.require('goog.userAgent');
+goog.require('goog.debug.ErrorHandler');
+goog.require('goog.events.EventWrapper');
+goog.require('goog.events.EventId');
+goog.require('goog.events.EventLike');
+goog.require('goog.events.EventWrapper');
 
 
 // Turn off debugging when compiled.


### PR DESCRIPTION
Problems generated when "build.py" is executed:

`FATAL ERROR
Required namespace "goog.events.EventWrapper" never defined.
??? at line 55:
goog.requireType('goog.events.EventWrapper');`

Fixed by adding the required namespaces to "blockly.js".

And while at it, optional use_closure_library changed to true.
That can increase the compression ratio.

It is built and test using Python 2.7.12 on Windows10.
